### PR TITLE
Fix link "Contributing to an Open Source Project"

### DIFF
--- a/about/simple_flow.md
+++ b/about/simple_flow.md
@@ -24,7 +24,7 @@ and finally submit the file using the 'Propose new file' button.
 
 Note: Since you are creating a file in a project you don’t have write access to. Submitting a 
 change will create the file in a new branch in your fork, so you can send a pull request. Visit 
-[Contributing to an Open Source Project][6] for more details on fork and pull request.
+[Contributing to an Open Source Project][4] for more details on fork and pull request.
 
 ### Prerequisites
 


### PR DESCRIPTION
[Contributing to an Open Source Project][6] should be [Contributing to an Open Source Project][4]

The reference [6] does not exist causing the markdown viewer to display the markdown source instead of an actual link.

The correct reference should be [4]