### PR TITLE
Get ready for Heroku deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
 FROM uribench/madness:1.0.3
 
-ENV PORT 3000
-
 COPY . .
-COPY entrypoint /bin/entrypoint
 
-RUN chmod +x /bin/entrypoint
-
-ENTRYPOINT ["bash"]
-CMD ["/bin/entrypoint"]
+ENTRYPOINT ["bash", "-c"]
+CMD ["madness --theme /_theme --port ${PORT:-3000}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
 FROM uribench/madness:1.0.3
+
+ENV PORT 3000
+
 COPY . .
-ENTRYPOINT ["madness", "--theme=/_theme"]
+COPY entrypoint /bin/entrypoint
+
+RUN chmod +x /bin/entrypoint
+
+ENTRYPOINT ["bash"]
+CMD ["/bin/entrypoint"]

--- a/entrypoint
+++ b/entrypoint
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-madness --theme /_theme --port $PORT

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+madness --theme /_theme --port $PORT

--- a/op.conf
+++ b/op.conf
@@ -2,10 +2,10 @@
 build: docker build -t uribench/handbook .
 
 # Run the docker container, with local volume mount
-run: docker run -it --rm -p 3000:3000 -e PORT -v $PWD:/docs uribench/handbook
+run: docker run -it --rm -p 3000:${PORT:-3000} -e PORT -v $PWD:/docs uribench/handbook
 
 # Run the docker container, without local volume mount
-run-no-vol: docker run -it --rm -p 3000:3000 -e PORT uribench/handbook
+run-no-vol: docker run -it --rm -p 3000:${PORT:-3000} -e PORT uribench/handbook
 
 # Start the madness server with local theme
 madness: madness --theme _theme

--- a/op.conf
+++ b/op.conf
@@ -1,10 +1,14 @@
+# Build the docker container
 build: docker build -t uribench/handbook .
-run: docker run -it --rm -p3000:3000 -v $PWD:/docs uribench/handbook
-deploy: now --public && now alias
+
+# Run the docker container, with local volume mount
+run: docker run -it --rm -p 3000:3000 -e PORT -v $PWD:/docs uribench/handbook
+
+# Run the docker container, without local volume mount
+run-no-vol: docker run -it --rm -p 3000:3000 -e PORT uribench/handbook
+
+# Start the madness server with local theme
 madness: madness --theme _theme
 
-# Run without volumes, to verify the container is alright
-clean-run: docker run -it --rm -p3000:3000  uribench/handbook
-
 # Deploy to Heroku. Change the dannyb-handbook appname to any new Heroku app
-heroku-deploy: heroku container:push web --app dannyb-handbook && heroku container:release web --app dannyb-handbook
+deploy: heroku container:push web --app dannyb-handbook && heroku container:release web --app dannyb-handbook

--- a/op.conf
+++ b/op.conf
@@ -2,3 +2,9 @@ build: docker build -t uribench/handbook .
 run: docker run -it --rm -p3000:3000 -v $PWD:/docs uribench/handbook
 deploy: now --public && now alias
 madness: madness --theme _theme
+
+# Run without volumes, to verify the container is alright
+clean-run: docker run -it --rm -p3000:3000  uribench/handbook
+
+# Deploy to Heroku. Change the dannyb-handbook appname to any new Heroku app
+heroku-deploy: heroku container:push web --app dannyb-handbook && heroku container:release web --app dannyb-handbook

--- a/op.conf
+++ b/op.conf
@@ -1,4 +1,4 @@
-# Build the docker container
+# Build the docker image
 build: docker build -t uribench/handbook .
 
 # Run the docker container, with local volume mount
@@ -10,5 +10,6 @@ run-no-vol: docker run -it --rm -p 3000:${PORT:-3000} -e PORT uribench/handbook
 # Start the madness server with local theme
 madness: madness --theme _theme
 
-# Deploy to Heroku. Change the dannyb-handbook appname to any new Heroku app
+# Deploy to Heroku. 
+# TODO: Change dannyb-handbook appname to any new Heroku app
 deploy: heroku container:push web --app dannyb-handbook && heroku container:release web --app dannyb-handbook

--- a/op.conf
+++ b/op.conf
@@ -11,5 +11,4 @@ run-no-vol: docker run -it --rm -p 3000:${PORT:-3000} -e PORT uribench/handbook
 madness: madness --theme _theme
 
 # Deploy to Heroku. 
-# TODO: Change dannyb-handbook appname to any new Heroku app
-deploy: heroku container:push web --app dannyb-handbook && heroku container:release web --app dannyb-handbook
+deploy: heroku container:push web --app software-engineering-handbook && heroku container:release web --app software-engineering-handbook


### PR DESCRIPTION
This PR adjusts the Docker configuration to allow deploying using Heroku containers.

The result is here: https://dannyb-handbook.herokuapp.com/ (that is a free tier, so it might cold-boot)

Since Heroku requires that we use the `$PORT` variable when running the app in the container, a few modifications were made:

1. The Dockerfile's `ENTRYPOINT` and `CMD` were updated to properly use the `$PORT` environment variable, if it exists, or default to `3000` if it does not.
2. The `op deploy` command was replaced, and it is now pointing to a Heroku deploy rather than a Now deploy.
3. A new `op run-no-vol` command was added, to run the docker image locally, but without any volumes - to allow debugging the actual container.

---

**⚠️ Attention**

Before merging, we should probably:

- [x] Change the Heroku appname
- [x] Remove all `now` commands from the `opcode` file, and leave only Heroku commands
- [x] ~Consider moving the `entrypoint` script upstream, to the `uribench/madness` docker image~ - `entrypoint` script removed altogether.
